### PR TITLE
Enhance validation

### DIFF
--- a/ll-time-input.html
+++ b/ll-time-input.html
@@ -88,9 +88,30 @@ Example:
      * @private
      */
     _isoToDisplay: function (isoStr) {
-      var m = moment(isoStr, 'HH:mm:ss');
-      if (m.isValid()) {
+      var m = this._getValidIsoMoment(isoStr);
+      if (!!m) {
         return m.format('h:mm A');
+      }
+    },
+
+    _getValidity: function () {
+      var m = this._getValidIsoMoment(this.dataIso);
+      var result = !!m;
+      this._toggleFormGroupError(!result);
+      return result;
+    },
+
+    _toggleFormGroupError: function (hasError) {
+      var par = Polymer.dom(this.root).parentNode;
+      if (par.classList.contains('form-group')) {
+        par.classList.toggle('has-error', hasError);
+      }
+    },
+
+    _getValidIsoMoment: function (str) {
+      var m = moment(str, 'HH:mm:ss');
+      if (m.isValid()) {
+        return m;
       }
     }
 

--- a/ll-time-input.html
+++ b/ll-time-input.html
@@ -43,7 +43,7 @@ Example:
       this.readOnly = true;
     },
 
-    ready: function() {
+    ready: function () {
       this.style.cursor = 'pointer';
     },
 

--- a/ll-time-input.html
+++ b/ll-time-input.html
@@ -30,6 +30,11 @@ Example:
         observer: '_isoChanged'
       },
 
+      value: {
+        type: String,
+        reflectToAttribute: true
+      },
+
       /**
        * The one instance of ll-time-picker created by this or another ll-time-input instance.
        */

--- a/ll-time-input.html
+++ b/ll-time-input.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 <link rel="import" href="../ll-time-picker/ll-time-picker.html">
 
 <script src="../moment/min/moment.min.js"></script>
@@ -34,6 +36,8 @@ Example:
       _timePicker: Object
 
     },
+
+    behaviors: [Polymer.IronFormElementBehavior, Polymer.IronValidatableBehavior],
 
     created: function () {
       this.readOnly = true;

--- a/ll-time-input.html
+++ b/ll-time-input.html
@@ -94,7 +94,7 @@ Example:
      */
     _isoToDisplay: function (isoStr) {
       var m = this._getValidIsoMoment(isoStr);
-      if (!!m) {
+      if (m) {
         return m.format('h:mm A');
       }
     },


### PR DESCRIPTION
This PR does 2 things:
- Implements IronFormElementBehavior and IronValidatableBehavior on ll-time-input so that it can be validated along with other native elements in an iron-form. In other words, when the iron-form containing this input is submitted, it will set the "invalid" attribute of this input to true if the input has the "required" attribute set and does not have a valid data-iso attribute value.
- When the above happens, and this input becomes invalid or invalid, it will toggle the 'has-error' class of its parent element if that parent element has the 'form-group' class. 
